### PR TITLE
Fix search results which are limited to a namespace

### DIFF
--- a/action.php
+++ b/action.php
@@ -153,7 +153,11 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
         // create filter from term and namespace
         $filter = array('tag' => $tag);
         if(isset($terms['ns'][0])) {
-            $filter['pid'] = $terms['ns'][0].':%';
+            $filter['pid'] = $terms['ns'][0];//.':%';
+            if (substr($filter['pid'],-1) !== ':') {
+                $filter['pid'] .= ':';
+            }
+            $filter['pid'] .= '%';
         }
 
         /** @var helper_plugin_tagging $hlp */


### PR DESCRIPTION
Search results like ``SearchWord @namespace:`` as opposed to ``SearchWord @namespace`` (notice the colon at the end of ``@namespace``) were broken, because the tagging plugin always added another colon to the end of its internal namespace filter. This PR fixes this.