### PR TITLE
Check search results against $conf['hidepages'] and ACL

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -161,7 +161,9 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
 
         $ret = array();
         foreach($res as $row) {
-            $ret[$row['item']] = $row['cnt'];
+            if (!isHiddenPage($row['item']) && auth_quickaclcheck($row['item']) >= AUTH_READ) {
+                $ret[$row['item']] = $row['cnt'];
+            }
         }
         return $ret;
     }


### PR DESCRIPTION
Before returning search results in findItems() inside helper.php, check against $conf['hidepages'] and ACL.