### PR TITLE
Fixed class name to correct wired layout

### DIFF
--- a/action.php
+++ b/action.php
@@ -180,7 +180,7 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
 
         // create output HTML
         $results = '<h3>'.$this->getLang('search_section_title').'</h3>';
-        $results .= '<div class="search_quickresults">';
+        $results .= '<div class="search_quickresult">';
         $results .= '<ul class="search_quickhits">';
         global $ID;
         $oldID = $ID;


### PR DESCRIPTION
Class name in dokuwiki is search_quickresult, not search_quickresults, see html_search() for reference.
Led to wired layout, at least with templates using margins for example.