### PR TITLE
Add quotes to tags with underscore or minus, fix Layout and improve results-heading

### DIFF
--- a/action.php
+++ b/action.php
@@ -180,7 +180,7 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
 
         // create output HTML
         $results = '<div class="search_quickresult">';
-        $results .= '<h3>'.$this->getLang('search_section_title').'</h3>';
+        $results .= '<h3>'.$this->getLang('search_section_title'). ' "' . $tag . '"' . '</h3>';
         $results .= '<ul class="search_quickhits">';
         global $ID;
         $oldID = $ID;

--- a/action.php
+++ b/action.php
@@ -180,7 +180,7 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
 
         // create output HTML
         $results = '<div class="search_quickresult">';
-        $results .= '<h3>'.$this->getLang('search_section_title'). ' "' . $tag . '"' . '</h3>';
+        $results .= '<h3>'.$this->getLang('search_section_title'). ' "' . hsc($tag) . '"' . '</h3>';
         $results .= '<ul class="search_quickhits">';
         global $ID;
         $oldID = $ID;

--- a/action.php
+++ b/action.php
@@ -179,8 +179,8 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
         if(!count($pages)) return;
 
         // create output HTML
-        $results = '<h3>'.$this->getLang('search_section_title').'</h3>';
-        $results .= '<div class="search_quickresults">';
+        $results = '<div class="search_quickresult">';
+        $results .= '<h3>'.$this->getLang('search_section_title').'</h3>';
         $results .= '<ul class="search_quickhits">';
         global $ID;
         $oldID = $ID;
@@ -192,6 +192,7 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
         }
         $ID = $oldID;
         $results .= '</ul>';
+        $results .= '<div class="clearer"></div>';
         $results .= '</div>';
 
         // insert it right after second level headline

--- a/helper.php
+++ b/helper.php
@@ -49,6 +49,8 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
      */
     public function cleanTag($tag) {
         $tag = str_replace(' ', '', $tag);
+        $tag = str_replace('-', '', $tag);
+        $tag = str_replace('_', '', $tag);
         $tag = utf8_strtolower($tag);
         return $tag;
     }

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -14,6 +14,6 @@ $lang['admin enter tag names']     = 'Bitte geben Sie den aktuellen und den neue
 $lang['admin tag does not exists'] = 'Ihr eingegebener Tagname existiert nicht';
 $lang['admin saved']               = 'Gespeichert';
 
-$lang['search_section_title'] = 'Getaggte Seiten';
+$lang['search_section_title'] = 'Seiten mit Tag';
 $lang['js']['notags']         = 'Keine Tags vergeben';
 $lang['js']['nopages']        = 'Keine Seiten mit diesem Tag';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -15,7 +15,7 @@ $lang['admin enter tag names']     = 'Please enter the current and the new tag n
 $lang['admin tag does not exists'] = 'The tag name you entered does not exist.';
 $lang['admin renamed']             = 'Your tag has been renamed';
 
-$lang['search_section_title'] = 'Tagged pages:';
+$lang['search_section_title'] = 'Pages tagged';
 $lang['js']['notags']         = 'No tags, yet';
 $lang['js']['nopages']        = 'No pages with this tag, yet';
 


### PR DESCRIPTION
  * fixes a layout issue where sometimes a linebreak was missing, if there where no matching pagenames ( commit cde21db )
  * adds quotes to searchstring when clicking tags containing ``-`` or ``_`` ( commit 5054799 )
  * shows the tag used for a search in the heading of the corresponding section ( commit 6ad0285 )

The last change may affect the Korean translation. Maybe @araname could check it?