### PR TITLE
Move ACL-Check to SQL-Query to respect LIMIT

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -132,6 +132,8 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
                 }
             }
         }
+        $where .= 'AND GETACCESSLEVEL(item) >= ' . AUTH_READ;
+
         // group and order
         if($type == 'tag') {
             $groupby = 'CLEANTAG(tag)';
@@ -163,7 +165,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
 
         $ret = array();
         foreach($res as $row) {
-            if (!isHiddenPage($row['item']) && auth_quickaclcheck($row['item']) >= AUTH_READ) {
+            if (!isHiddenPage($row['item'])) {
                 $ret[$row['item']] = $row['cnt'];
             }
         }

--- a/helper.php
+++ b/helper.php
@@ -165,9 +165,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
 
         $ret = array();
         foreach($res as $row) {
-            if (!isHiddenPage($row['item'])) {
-                $ret[$row['item']] = $row['cnt'];
-            }
+            $ret[$row['item']] = $row['cnt'];
         }
         return $ret;
     }


### PR DESCRIPTION
As correctly pointed out by @Klap-in in issue #18  and pull request #12, it is better to use GETACCESSLEVEL inside the query. While the LIMIT may still be enforced incorrectly when pages are hidden, this should now happen less often.