### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -5,7 +5,7 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
     /**
      * Register handlers
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook(
             'TPL_CONTENT_DISPLAY', 'BEFORE', $this,
             'echo_searchresults'

--- a/syntax.php
+++ b/syntax.php
@@ -27,7 +27,7 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('{{tagging::\w+(?:>[^}\?]+)?(?:\?[0-9]+)?}}', $mode, 'plugin_tagging');
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         $data    = array();
         $matches = array();
         preg_match('/{{tagging::(\w+)(?:>([^}\?]+))?(\?[0-9]+)?}}/', $match, $matches);
@@ -51,7 +51,7 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
         return $data;
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode !== 'xhtml') {
             return false;
         }


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.