### PR TITLE
fixed acl check

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -132,7 +132,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
                 }
             }
         }
-        $where .= 'AND GETACCESSLEVEL(item) >= ' . AUTH_READ;
+        $where .= 'AND GETACCESSLEVEL(pid) >= ' . AUTH_READ;
 
         // group and order
         if($type == 'tag') {


### PR DESCRIPTION
The original code called GETACCESSLEVEL(item), with item being some tag (that doesn't really make sense). I guess it's supposed to check the access level of the respective page, so we need to call GETACCESSLEVEL(pid) (pid being the page id).
