### PR TITLE
Table sorting on admin page

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -50,9 +50,8 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
         }
 
         switch ($cmd) {
-            case 'rename'    : $this->_renameTag(); break;
-            case 'delete'    : $this->_deleteTags(); break;
-            case 'sort'      : break;
+            case 'rename'    : $this->hlp->renameTag($INPUT->str('old'), $INPUT->str('new')); break;
+            case 'delete'    : $this->hlp->deleteTags(array_keys($INPUT->arr('tags')), $INPUT->str('filter')); break;
         }
     }
 
@@ -164,29 +163,5 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
         
         $form->addTagClose('table');
         echo $form->toHTML();        
-    }
-    
-    /**
-     * Rename a tag
-     *
-     */
-    protected function _renameTag() {
-        global $INPUT;
-        
-        if ($INPUT->post->has('old') && $INPUT->post->has('new')) {
-            $this->hlp->renameTag($INPUT->post->str('old'), $INPUT->post->str('new'));
-        }
-    }
-    
-    /**
-     * Delete tags
-     *
-     */
-    protected function _deleteTags() {
-        global $INPUT;
-        
-        if ($INPUT->post->has('tags')) {
-            $this->hlp->deleteTags(array_keys($INPUT->post->arr('tags')), $INPUT->str('filter'));
-        }
     }
 }

--- a/admin.php
+++ b/admin.php
@@ -170,9 +170,12 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
         $form->addTagClose('tr');
 
         foreach ($tags as $taginfo) {
+            sort($taginfo['taggers']);
+            sort($taginfo['orig']);
+            
             $tagname = $taginfo['tid'];
-            $taggers = $taginfo['taggers'];
-            $written = $taginfo['orig'];
+            $taggers = implode(', ', $taginfo['taggers']);
+            $written = implode(', ', $taginfo['orig']);
 
             $form->addTagOpen('tr');
             $form->addTagOpen('td')->addClass('centeralign');

--- a/admin.php
+++ b/admin.php
@@ -132,12 +132,10 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
         }
         $form->addTagClose('tr');
 
-        foreach ($tags as $tagname => $taginfo) {
-            $taggers = array_unique($taginfo['tagger']);
-            sort($taggers);
-            $written = array_unique($taginfo['orig']);
-            $taggers = join(', ', $taggers);
-            $written = join(', ', $written);
+        foreach ($tags as $taginfo) {
+            $tagname = $taginfo['tid'];
+            $taggers = $taginfo['taggers'];
+            $written = $taginfo['orig'];
 
             $form->addTagOpen('tr');
             $form->addTagOpen('td')->addClass('centeralign');

--- a/admin.php
+++ b/admin.php
@@ -52,6 +52,7 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
         switch ($cmd) {
             case 'rename'    : $this->_renameTag(); break;
             case 'delete'    : $this->_deleteTags(); break;
+            case 'sort'      : break;
         }
     }
 
@@ -97,11 +98,11 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
         global $ID, $INPUT;
         
         $headers = array(
-            '&#160;',
-            $this->getLang('admin tag'),
-            $this->getLang('admin occurrence'),
-            $this->getLang('admin writtenas'),
-            $this->getLang('admin taggers')
+            array('value' => '&#160;',                           'sort_by' => false),
+            array('value' => $this->getLang('admin tag'),        'sort_by' => 'tid'),
+            array('value' => $this->getLang('admin occurrence'), 'sort_by' => 'count'),
+            array('value' => $this->getLang('admin writtenas'),  'sort_by' => 'orig'),
+            array('value' => $this->getLang('admin taggers'),    'sort_by' => 'taggers')
         );
         $tags = $this->hlp->getAllTags($INPUT->str('filter'));
         
@@ -128,7 +129,12 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
          */        
         $form->addTagOpen('tr');
         foreach ($headers as $header) {
-            $form->addHTML('<th>' . $header . '</th>');
+            $form->addTagOpen('th');
+            $form->addHTML($header['value']);
+            if ($header['sort_by'] !== false) {
+                $form->addButton("fn[sort][$header[sort_by]]", 'sort');
+            }
+            $form->addTagClose('th');
         }
         $form->addTagClose('tr');
 

--- a/helper.php
+++ b/helper.php
@@ -386,10 +386,10 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         
         $query = 'SELECT    pid,
                             CLEANTAG(tag) as tid,
-                            GROUP_CONCAT(tag, ", ") AS orig,
-                            GROUP_CONCAT(tagger, ", ") AS taggers,
+                            GROUP_CONCAT(tag) AS orig,
+                            GROUP_CONCAT(tagger) AS taggers,
                             COUNT(*) AS "count"
-                        FROM (SELECT * FROM "taggings" ORDER BY tagger) /*sort taggers inside GROUP_CONCAT*/
+                        FROM "taggings"
                         WHERE pid LIKE ?
                         GROUP BY tid
                         ORDER BY '.$order_by;
@@ -397,7 +397,12 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         
         $res = $db->query($query, $this->globNamespace($namespace));
         
-        return $db->res2arr($res);
+        return array_map(
+                function($record) {
+                    $record['orig'] = explode(',', $record['orig']);
+                    $record['taggers'] = explode(',', $record['taggers']);
+                    return $record;
+                }, $db->res2arr($res));
     }
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -372,7 +372,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
      * @return array
      */
     public function getAllTags($namespace='', $order_by='tag', $desc=false) {
-        $order_fields = array('tag', 'orig', 'taggers', 'count');
+        $order_fields = array('pid', 'tid', 'orig', 'taggers', 'count');
         if (!in_array($order_by, $order_fields))
             throw new Exception('cannot sort by '.$order_by. ' field does not exists');
         

--- a/helper.php
+++ b/helper.php
@@ -371,7 +371,10 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
      * 
      * @return array
      */
-    public function getAllTags($namespace='') {
+    public function getAllTags($namespace='', $order_by='tag', $desc=false) {
+        $order_fields = array('tag', 'orig', 'taggers', 'count');
+        if (!in_array($order_by, $order_fields))
+            throw new Exception('cannot sort by '.$order_by. ' field does not exists');
         
         $db = $this->getDb();
         
@@ -383,7 +386,9 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
                         FROM (SELECT * FROM "taggings" ORDER BY tagger) /*sort taggers inside GROUP_CONCAT*/
                         WHERE pid LIKE ?
                         GROUP BY tid
-                        ORDER BY tag';
+                        ORDER BY '.$order_by;
+        if ($desc) $query .= ' DESC';
+        
         $res = $db->query($query, $this->globNamespace($namespace));
         
         return $db->res2arr($res);

--- a/images/arrow-both.svg
+++ b/images/arrow-both.svg
@@ -1,4 +1,3 @@
-<svg viewbox="0 0 20 20">
-    <polygon points="2,8, 18,8 10,0"/> <!-- arrow up -->
-    <polygon points="2,12, 18,12 10,20"/> <!-- arrow down -->
+<svg width="20" height="20" viewbox="0 0 20 20">
+    <path d="M 2 8 H 18 L 10 0 L 2 8 M 2 12 H 18 L 10 20 L 2 12"/>
 </svg>

--- a/images/arrow-both.svg
+++ b/images/arrow-both.svg
@@ -1,0 +1,4 @@
+<svg viewbox="0 0 20 20">
+    <polygon points="2,8, 18,8 10,0"/> <!-- arrow up -->
+    <polygon points="2,12, 18,12 10,20"/> <!-- arrow down -->
+</svg>

--- a/images/arrow-down.svg
+++ b/images/arrow-down.svg
@@ -1,0 +1,3 @@
+<svg viewbox="0 0 20 20">
+    <polygon points="2,6, 18,6 10,14"/>
+</svg>

--- a/images/arrow-down.svg
+++ b/images/arrow-down.svg
@@ -1,3 +1,3 @@
-<svg viewbox="0 0 20 20">
+<svg width="20" height="20" viewbox="0 0 20 20">
     <polygon points="2,6, 18,6 10,14"/>
 </svg>

--- a/images/arrow-up.svg
+++ b/images/arrow-up.svg
@@ -1,3 +1,3 @@
-<svg viewbox="0 0 20 20">
+<svg width="20" height="20" viewbox="0 0 20 20">
     <polygon points="2,14, 18,14 10,6"/>
 </svg>

--- a/images/arrow-up.svg
+++ b/images/arrow-up.svg
@@ -1,0 +1,3 @@
+<svg viewbox="0 0 20 20">
+    <polygon points="2,14, 18,14 10,6"/>
+</svg>

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -18,6 +18,8 @@ $lang['admin renamed']             = 'Your tag has been renamed';
 $lang['admin delete_selected']     = 'Delete Selected';
 $lang['admin filter button']       = 'Filter';
 $lang['admin deleted']             = 'You have deleted %d tags on %d pages';
+$lang['admin sort ascending']      = 'Sort ascending';
+$lang['admin sort descending']     = 'Sort descending';
 
 $lang['search_section_title'] = 'Pages tagged';
 $lang['js']['notags']         = 'No tags, yet';

--- a/style.less
+++ b/style.less
@@ -67,3 +67,23 @@ ul.tagging_cloud {
         font-size: 2em;
     }
 }
+
+button.plugin_tagging.sort_button {
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: #2b73b7;
+    
+    &:hover {
+        text-decoration: underline;
+    }
+    &:focus {
+        outline:0;
+    }
+    
+    svg {
+        transform: scale(0.5);
+        vertical-align: middle;
+    }
+}

--- a/style.less
+++ b/style.less
@@ -83,7 +83,8 @@ button.plugin_tagging.sort_button {
     }
     
     svg {
-        transform: scale(0.5);
         vertical-align: middle;
+        width: 10px;
+        height: 10px;
     }
 }


### PR DESCRIPTION
Table headers behaves like buttons and allow user to sort the column in ascending and descending order. I've rebuild helper.php:getAllTags() to use SQL rather than PHP based parsing. It's faster and in my opinion makes the code more elegant.