### PR TITLE
Use textarea to edit tags

### DIFF
--- a/action.php
+++ b/action.php
@@ -199,9 +199,10 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
         }
         
         $tags = $hlp->findItems(array('pid' => $pid), 'tag');
+        $userTags = $hlp->findItems(array('pid' => $pid, 'tagger' => $hlp->getUser()), 'tag');
         echo $json->encode(array(
                                 'status'          => 'ok',
-                                'tags_edit_value' => implode(', ', array_keys($tags)),
+                                'tags_edit_value' => implode(', ', array_keys($userTags)),
                                 'html_cloud'      => $hlp->html_cloud($tags, 'tag', array($hlp, 'linkToSearch'), false, true)
                         ));
     }

--- a/action.php
+++ b/action.php
@@ -23,13 +23,13 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
             'ACTION_ACT_PREPROCESS', 'BEFORE', $this,
             'handle_jump'
         );
-        
+
         $controller->register_hook(
-            'DOKUWIKI_STARTED', 'AFTER',  $this,
+            'DOKUWIKI_STARTED', 'AFTER', $this,
             'js_add_security_token'
         );
     }
-    
+
     /**
      * Add sectok to JavaScript to secure ajax requests
      *
@@ -155,56 +155,60 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
         $json = new JSON();
         echo $json->encode(array_combine($tags, $tags));
     }
-    
+
     /**
      * Allow admins to change all tags (not only their own)
      * We change the tag for every user
      */
     function admin_change() {
         global $INPUT;
-        
+
         /** @var helper_plugin_tagging $hlp */
         $hlp = plugin_load('helper', 'tagging');
 
         header('Content-Type: application/json');
         $json = new JSON();
-        
-       if (!auth_isadmin()) {
+
+        if (!auth_isadmin()) {
             echo $json->encode(array('status' => 'error', 'msg' => $this->getLang('no_admin')));
+
             return;
         }
-        
+
         if (!checkSecurityToken()) {
-             echo $json->encode(array('status' => 'error', 'msg' => 'Security Token did not match. Possible CSRF attack.'));
-             return;
+            echo $json->encode(array('status' => 'error', 'msg' => 'Security Token did not match. Possible CSRF attack.'));
+
+            return;
         }
-        
+
         if (!$INPUT->has('id')) {
             echo $json->encode(array('status' => 'error', 'msg' => 'No page id given.'));
+
             return;
         }
         $pid = $INPUT->str('id');
-        
+
         if (!$INPUT->has('oldValue') || !$INPUT->has('newValue')) {
             echo $json->encode(array('status' => 'error', 'msg' => 'No proper input. Give "oldValue" and "newValue"'));
+
             return;
         }
-        
- 
-        
+
+
         list($err, $msg) = $hlp->modifyPageTag($pid, $INPUT->str('oldValue'), $INPUT->str('newValue'));
         if ($err) {
             echo $json->encode(array('status' => 'error', 'msg' => $msg));
-            return;  
+
+            return;
         }
-        
+
         $tags = $hlp->findItems(array('pid' => $pid), 'tag');
         $userTags = $hlp->findItems(array('pid' => $pid, 'tagger' => $hlp->getUser()), 'tag');
         echo $json->encode(array(
-                                'status'          => 'ok',
-                                'tags_edit_value' => implode(', ', array_keys($userTags)),
-                                'html_cloud'      => $hlp->html_cloud($tags, 'tag', array($hlp, 'linkToSearch'), false, true)
-                        ));
+            'status'          => 'ok',
+            'tags_edit_value' => implode(', ', array_keys($userTags)),
+            'html_cloud'      => $hlp->html_cloud($tags, 'tag', array($hlp, 'linkToSearch'), false, true),
+        ));
     }
 
     /**

--- a/action.php
+++ b/action.php
@@ -126,7 +126,7 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
             $hlp->replaceTags(
                 $id, $hlp->getUser(),
                 preg_split(
-                    '/\s*,\s*/', $data['tags'], -1,
+                    '/(\s*,\s*)|(\s*,?\s*\n\s*)/', $data['tags'], -1,
                     PREG_SPLIT_NO_EMPTY
                 )
             );

--- a/admin.php
+++ b/admin.php
@@ -10,7 +10,7 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
     private $hlp;
 
     public function __construct() {
-        $this->hlp      = plugin_load('helper', 'tagging');
+        $this->hlp = plugin_load('helper', 'tagging');
     }
 
     /**
@@ -27,21 +27,29 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
      */
     function handle() {
         global $ID, $INPUT;
-        
+
         //by default use current page namespace
-        if (!$INPUT->has('filter')) $INPUT->set('filter', getNS($ID));
-        
+        if (!$INPUT->has('filter')) {
+            $INPUT->set('filter', getNS($ID));
+        }
+
 
         //by default sort by tag name
-        if (!$INPUT->has('sort')) $INPUT->set('sort', 'tid');
-        
+        if (!$INPUT->has('sort')) {
+            $INPUT->set('sort', 'tid');
+        }
+
         //now starts functions handle
-        if (!$INPUT->has('fn')) return false;
-        if (!checkSecurityToken()) return false;
-        
+        if (!$INPUT->has('fn')) {
+            return false;
+        }
+        if (!checkSecurityToken()) {
+            return false;
+        }
+
         // extract the command and any specific parameters
         // submit button name is of the form - fn[cmd][param(s)]
-        $fn   = $INPUT->param('fn');
+        $fn = $INPUT->param('fn');
 
         if (is_array($fn)) {
             $cmd = key($fn);
@@ -61,7 +69,7 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
             case 'sort':
                 $INPUT->set('sort', $param);
                 break;
-            
+
         }
     }
 
@@ -80,16 +88,16 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
      */
     protected function html_form() {
         global $ID, $INPUT;
-        
+
         $form = new dokuwiki\Form\Form();
         $form->addClass('plugin_tagging');
-        
-        $form->setHiddenField('do',    'admin');
-        $form->setHiddenField('page',  'tagging');
-        $form->setHiddenField('id',     $ID);
+
+        $form->setHiddenField('do', 'admin');
+        $form->setHiddenField('page', 'tagging');
+        $form->setHiddenField('id', $ID);
         $form->setHiddenField('filter', $INPUT->str('filter'));
         $form->setHiddenField('sort', $INPUT->str('sort'));
-        
+
         $form->addFieldsetOpen($this->getLang('admin rename tag'));
         $form->addTextInput('old', $this->getLang('admin find tag'))->addClass('block');
         $form->addTagClose('br');
@@ -97,7 +105,7 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
         $form->addTagClose('br');
         $form->addButton('fn[rename]', $this->getLang('admin save'));
         $form->addFieldsetClose();
-        
+
         echo $form->toHTML();
     }
 
@@ -106,15 +114,15 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
      */
     protected function html_table() {
         global $ID, $INPUT;
-        
+
         $headers = array(
-            array('value' => '&#160;',                           'sort_by' => false),
-            array('value' => $this->getLang('admin tag'),        'sort_by' => 'tid'),
+            array('value' => '&#160;', 'sort_by' => false),
+            array('value' => $this->getLang('admin tag'), 'sort_by' => 'tid'),
             array('value' => $this->getLang('admin occurrence'), 'sort_by' => 'count'),
-            array('value' => $this->getLang('admin writtenas'),  'sort_by' => 'orig'),
-            array('value' => $this->getLang('admin taggers'),    'sort_by' => 'taggers')
+            array('value' => $this->getLang('admin writtenas'), 'sort_by' => 'orig'),
+            array('value' => $this->getLang('admin taggers'), 'sort_by' => 'taggers'),
         );
-        
+
         $sort = explode(',', $INPUT->str('sort'));
         $order_by = $sort[0];
         $desc = false;
@@ -122,29 +130,29 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
             $desc = true;
         }
         $tags = $this->hlp->getAllTags($INPUT->str('filter'), $order_by, $desc);
-        
+
         $form = new dokuwiki\Form\Form();
-        $form->setHiddenField('do',   'admin');
+        $form->setHiddenField('do', 'admin');
         $form->setHiddenField('page', 'tagging');
-        $form->setHiddenField('id',    $ID);
+        $form->setHiddenField('id', $ID);
         $form->setHiddenField('sort', $INPUT->str('sort'));
-        
+
         $form->addTagOpen('table')->addClass('inline plugin_tagging');
         $form->addTagOpen('tr');
         $form->addTagOpen('th')->attr('colspan', count($headers));
-        
+
         /**
          * Show form for filtering the tags by namespaces
          */
-        $form->addTextInput('filter', $this->getLang('admin filter').': ');
+        $form->addTextInput('filter', $this->getLang('admin filter') . ': ');
         $form->addButton('fn[filter]', $this->getLang('admin filter button'));
-        
+
         $form->addTagClose('th');
         $form->addTagClose('tr');
-        
+
         /**
          * Table headers
-         */        
+         */
         $form->addTagOpen('tr');
         foreach ($headers as $header) {
             $form->addTagOpen('th');
@@ -158,12 +166,12 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
                         $title = $this->getLang('admin sort descending');
                         $param .= ',desc';
                     } else {
-                         $icon = 'arrow-down';
+                        $icon = 'arrow-down';
                     }
                 }
-                $form->addButtonHTML("fn[sort][$param]", $header['value']. ' '. inlineSVG(dirname(__FILE__) . "/images/$icon.svg"))
-                                    ->addClass('plugin_tagging sort_button')
-                                    ->attr('title', $title);
+                $form->addButtonHTML("fn[sort][$param]", $header['value'] . ' ' . inlineSVG(dirname(__FILE__) . "/images/$icon.svg"))
+                    ->addClass('plugin_tagging sort_button')
+                    ->attr('title', $title);
             }
             $form->addTagClose('th');
         }
@@ -176,14 +184,14 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
 
             $form->addTagOpen('tr');
             $form->addTagOpen('td')->addClass('centeralign');
-            $form->addCheckbox('tags['.hsc($tagname).']');
+            $form->addCheckbox('tags[' . hsc($tagname) . ']');
             $form->addTagClose('td');
-            $form->addHTML('<td><a class="tagslist" href="' . 
-                    $this->hlp->getTagSearchURL($tagname) . '">' . hsc($tagname) . '</a></td>');
+            $form->addHTML('<td><a class="tagslist" href="' .
+                $this->hlp->getTagSearchURL($tagname) . '">' . hsc($tagname) . '</a></td>');
             $form->addHTML('<td>' . $taginfo['count'] . '</td>');
             $form->addHTML('<td>' . hsc($written) . '</td>');
             $form->addHTML('<td>' . hsc($taggers) . '</td>');
-            
+
             $form->addTagClose('tr');
         }
 
@@ -192,8 +200,8 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
         $form->addButton('fn[delete]', $this->getLang('admin delete_selected'))->id('tagging__del');
         $form->addHTML('</span></td>');
         $form->addTagClose('tr');
-        
+
         $form->addTagClose('table');
-        echo $form->toHTML();        
+        echo $form->toHTML();
     }
 }

--- a/helper.php
+++ b/helper.php
@@ -369,7 +369,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
                                         'pid' => $INFO['id'],
                                         'tagger' => $this->getUser()
                                     ), 'tag');
-            $form->addTextInput('tagging[tags]')->val(implode(', ', array_keys($tags)))->addClass('edit');
+            $form->addTextarea('tagging[tags]')->val(implode(', ', array_keys($tags)))->addClass('edit');
             $form->addButton('', $lang['btn_save'])->id('tagging__edit_save');
             $form->addButton('', $lang['btn_cancel'])->id('tagging__edit_cancel');
             $ret .= $form->toHTML();

--- a/helper.php
+++ b/helper.php
@@ -23,16 +23,19 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         $db = plugin_load('helper', 'sqlite');
         if (is_null($db)) {
             msg('The tagging plugin needs the sqlite plugin', -1);
+
             return false;
         }
         $db->init('tagging', dirname(__FILE__) . '/db/');
         $db->create_function('CLEANTAG', array($this, 'cleanTag'), 1);
         $db->create_function('GROUP_SORT',
-            function($group, $newDelimiter) {
+            function ($group, $newDelimiter) {
                 $ex = explode(',', $group);
                 sort($ex);
+
                 return implode($newDelimiter, $ex);
             }, 2);
+
         return $db;
     }
 
@@ -50,6 +53,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         if ($this->getConf('singleusermode')) {
             return 'auto';
         }
+
         return $_SERVER['REMOTE_USER'];
     }
 
@@ -65,6 +69,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         $tag = str_replace('-', '', $tag);
         $tag = str_replace('_', '', $tag);
         $tag = utf8_strtolower($tag);
+
         return $tag;
     }
 
@@ -110,9 +115,11 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         foreach ($queries as $query) {
             if (!call_user_func_array(array($db, 'query'), $query)) {
                 $db->query('ROLLBACK TRANSACTION');
+
                 return false;
             }
         }
+
         return $db->query('COMMIT TRANSACTION');
     }
 
@@ -195,6 +202,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         foreach ($res as $row) {
             $ret[$row['item']] = $row['cnt'];
         }
+
         return $ret;
     }
 
@@ -262,6 +270,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
                 $tags[$tag] = $levels;
             }
         }
+
         return $tags;
     }
 
@@ -315,6 +324,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             return $ret;
         }
         echo $ret;
+
         return '';
     }
 
@@ -366,9 +376,9 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $form->setHiddenField('tagging[id]', $INFO['id']);
             $form->setHiddenField('call', 'plugin_tagging_save');
             $tags = $this->findItems(array(
-                                        'pid' => $INFO['id'],
-                                        'tagger' => $this->getUser()
-                                    ), 'tag');
+                'pid'    => $INFO['id'],
+                'tagger' => $this->getUser(),
+            ), 'tag');
             $form->addTextarea('tagging[tags]')->val(implode(', ', array_keys($tags)))->addClass('edit');
             $form->addButton('', $lang['btn_save'])->id('tagging__edit_save');
             $form->addButton('', $lang['btn_cancel'])->id('tagging__edit_cancel');
@@ -379,6 +389,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         if ($print) {
             echo $ret;
         }
+
         return $ret;
     }
 
@@ -387,25 +398,27 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
      *
      * @return array
      */
-    public function getAllTags($namespace='', $order_by='tag', $desc=false) {
+    public function getAllTags($namespace = '', $order_by = 'tag', $desc = false) {
         $order_fields = array('pid', 'tid', 'orig', 'taggers', 'count');
         if (!in_array($order_by, $order_fields)) {
-            msg('cannot sort by '.$order_by. ' field does not exists', -1);
-            $order_by='tag';
+            msg('cannot sort by ' . $order_by . ' field does not exists', -1);
+            $order_by = 'tag';
         }
 
         $db = $this->getDb();
 
         $query = 'SELECT    "pid",
-                            CLEANTAG("tag") as "tid",
+                            CLEANTAG("tag") AS "tid",
                             GROUP_SORT(GROUP_CONCAT("tag"), \', \') AS "orig",
                             GROUP_SORT(GROUP_CONCAT("tagger"), \', \') AS "taggers",
                             COUNT(*) AS "count"
                         FROM "taggings"
                         WHERE "pid" LIKE ?
                         GROUP BY "tid"
-                        ORDER BY '.$order_by;
-        if ($desc) $query .= ' DESC';
+                        ORDER BY ' . $order_by;
+        if ($desc) {
+            $query .= ' DESC';
+        }
 
         $res = $db->query($query, $this->globNamespace($namespace));
 
@@ -422,6 +435,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
 
         if (empty($formerTagName) || empty($newTagName)) {
             msg($this->getLang("admin enter tag names"), -1);
+
             return;
         }
 
@@ -432,6 +446,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
 
         if (empty($check)) {
             msg($this->getLang("admin tag does not exists"), -1);
+
             return;
         }
 
@@ -439,6 +454,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         $db->res2arr($res);
 
         msg($this->getLang("admin renamed"), 1);
+
         return;
     }
 
@@ -448,7 +464,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
      * @param string $pid
      * @param string $formerTagName
      * @param string $newTagName
-     * 
+     *
      * @return array
      */
     public function modifyPageTag($pid, $formerTagName, $newTagName) {
@@ -461,7 +477,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         if (empty($check)) {
             return array(true, $this->getLang('admin tag does not exists'));
         }
-        
+
         if (empty($newTagName)) {
             $res = $db->query('DELETE FROM taggings WHERE pid = ? AND CLEANTAG(tag) = ?', $pid, $this->cleanTag($formerTagName));
         } else {
@@ -471,28 +487,31 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
 
         return array(false, $this->getLang('admin renamed'));
     }
-    
+
     /**
      * Deletes a tag
      *
-     * @param array $tags
+     * @param array  $tags
      * @param string $namespace current namespace context as in getAllTags()
      */
-    public function deleteTags($tags, $namespace='') {
-        if (empty($tags)) return;
+    public function deleteTags($tags, $namespace = '') {
+        if (empty($tags)) {
+            return;
+        }
 
         $namespace = cleanId($namespace);
 
         $db = $this->getDb();
 
         $query = 'DELETE FROM taggings WHERE pid LIKE ? AND (' .
-                                implode(' OR ', array_fill(0, count($tags), 'CLEANTAG(tag) = ?')).')';
+            implode(' OR ', array_fill(0, count($tags), 'CLEANTAG(tag) = ?')) . ')';
 
         $args = array_map(array($this, 'cleanTag'), $tags);
         array_unshift($args, $this->globNamespace($namespace));
         $res = $db->query($query, $args);
 
         msg(sprintf($this->getLang("admin deleted"), count($tags), $res->rowCount()), 1);
+
         return;
     }
 }

--- a/script.js
+++ b/script.js
@@ -5,7 +5,7 @@ jQuery(function () {
     /**
      * Add JavaScript confirmation to the User Delete button
      */
-    jQuery('#tagging__del').click(function(){
+    jQuery('#tagging__del').click(function () {
         return confirm(LANG.del_confirm);
     });
 
@@ -33,29 +33,30 @@ jQuery(function () {
     });
 
     var $admin_toggle_btn = jQuery('#tagging__edit_toggle_admin')
-                                .checkboxradio()
-                                .click(function(){
-                                    jQuery('div.plugin_tagging_edit ul.tagging_cloud a').editable('toggleDisabled');
-                                }),
-        add_editable = function() {
+            .checkboxradio()
+            .click(function () {
+                jQuery('div.plugin_tagging_edit ul.tagging_cloud a').editable('toggleDisabled');
+            }),
+        add_editable = function () {
             //no editable button - we are not the admin
             if ($admin_toggle_btn.length === 0) return;
 
             jQuery('div.plugin_tagging_edit ul.tagging_cloud a')
                 .editable({
-                    disabled  : !$admin_toggle_btn[0].checked,
-                    label     : LANG.plugins.tagging.admin_change_tag,
-                    url       : DOKU_BASE + 'lib/exe/ajax.php?call=plugin_tagging_admin_change',
-                    params    : { 'call'   : 'plugin_tagging_admin_change',
-                                  'id'     : JSINFO.id,
-                                  'sectok' : JSINFO.sectok
-                                },
-                    success   :
-                        function(response) {
-                            jQuery('div.plugin_tagging_edit ul.tagging_cloud').html(response.html_cloud);
-                            $form.find('textarea').val(response.tags_edit_value);
-                            add_editable();
-                        }
+                    disabled: !$admin_toggle_btn[0].checked,
+                    label:    LANG.plugins.tagging.admin_change_tag,
+                    url:      DOKU_BASE + 'lib/exe/ajax.php?call=plugin_tagging_admin_change',
+                    params:   {
+                        'call':   'plugin_tagging_admin_change',
+                        'id':     JSINFO.id,
+                        'sectok': JSINFO.sectok
+                    },
+                    success:
+                              function (response) {
+                                  jQuery('div.plugin_tagging_edit ul.tagging_cloud').html(response.html_cloud);
+                                  $form.find('textarea').val(response.tags_edit_value);
+                                  add_editable();
+                              }
                 });
         };
 
@@ -100,16 +101,16 @@ jQuery(function () {
 
     $form.find('textarea')
     // don't navigate away from the field on tab when selecting an item
-        .bind("keydown", function (event) {
+        .bind('keydown', function (event) {
             if (event.keyCode === jQuery.ui.keyCode.TAB &&
-                jQuery(this).data("ui-autocomplete").menu.active) {
+                jQuery(this).data('ui-autocomplete').menu.active) {
                 event.preventDefault();
             }
         })
         .autocomplete({
             source: function (request, response) {
                 jQuery.getJSON(DOKU_BASE + 'lib/exe/ajax.php?call=plugin_tagging_autocomplete', {
-                    term: extractLast(request.term),
+                    term: extractLast(request.term)
                 }, response);
             },
             search: function () {
@@ -120,7 +121,7 @@ jQuery(function () {
                 }
                 return true;
             },
-            focus: function () {
+            focus:  function () {
                 // prevent value inserted on focus
                 return false;
             },
@@ -131,9 +132,9 @@ jQuery(function () {
                 // add the selected item
                 terms.push(ui.item.value);
                 // add placeholder to get the comma-and-space at the end
-                terms.push("");
-                this.value = terms.join(", ");
+                terms.push('');
+                this.value = terms.join(', ');
                 return false;
-            },
+            }
         });
 });

--- a/script.js
+++ b/script.js
@@ -18,7 +18,7 @@ jQuery(function () {
     $btn.submit(function (e) {
         $btns.hide();
         $form.show();
-        var $input = $form.find('input[type="text"]');
+        var $input = $form.find('textarea');
         var len = $input.val().length;
         $input.focus();
         try {
@@ -53,7 +53,7 @@ jQuery(function () {
                     success   :
                         function(response) {
                             jQuery('div.plugin_tagging_edit ul.tagging_cloud').html(response.html_cloud);
-                            $form.find('input[type="text"]').val(response.tags_edit_value);
+                            $form.find('textarea').val(response.tags_edit_value);
                             add_editable();
                         }
                 });
@@ -98,7 +98,7 @@ jQuery(function () {
         return split(term).pop();
     }
 
-    $form.find('input[type="text"]')
+    $form.find('textarea')
     // don't navigate away from the field on tab when selecting an item
         .bind("keydown", function (event) {
             if (event.keyCode === jQuery.ui.keyCode.TAB &&


### PR DESCRIPTION
With many and/or long tags, the input field can be too small fast.

This also fixes a bug where all tags would be shown in the input after editing a tag with the new admin-tag interface.

Further this fixes all the files whitespace.