### PR TITLE
added another <h3> to searchresult page in action.php

### DIFF
--- a/action.php
+++ b/action.php
@@ -286,6 +286,7 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
         $results .= '</ul>';
         $results .= '<div class="clearer"></div>';
         $results .= '</div>';
+        $results .= '<h3>' . $this->getLang('search_section_title_other') . ' "' . hsc($tag) . '"' . '</h3>';
 
         if (preg_match('/<div class="nothing">.*?<\/div>/', $event->data)) {
             // there are no other hits, replace the nothing found

--- a/helper.php
+++ b/helper.php
@@ -404,7 +404,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         $namespace = array_pop(array_reverse(explode(":",$pid)));
         print "namespace from pid is $namespace";
         print "splitted value is $pidWONamespace";
-        return '<a href="' . hsc($this->getPidURL($pidWONamespace, $namespace)) . '">' . $pidWONamespace . '</a>';
+        return '<a href="' . $this->getPidURL($pidWONamespace, $namespace) . '">' . $pidWONamespace . '</a>';
     }
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -398,8 +398,10 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
     }
 
     protected function linkToPage($pid, $ns = '') {
-        print "trying to split the array";
-        $pidWONamespace = end(split(":",$pid));
+        print "trying to split the array from value $pid";
+        $splitted = split(":",$pid);
+        print_r($splitted);
+        $pidWONamespace = end($splitted);
         print "splitted value is $pidWONamespace";
         return '<a href="' . hsc($this->getPidURL($pid, $ns)) . '">' . $pidWONamespace . '</a>';
     }

--- a/helper.php
+++ b/helper.php
@@ -247,7 +247,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $pid = '"' . $pid . '"';
         }
 
-        $ret = "test"; //rawurlencode($pid);
+        $ret = $ns; //rawurlencode($pid);
         /*if ($ns) {
             $ret .= "rawurlencode(' @' . $ns)";
         }*/

--- a/helper.php
+++ b/helper.php
@@ -399,9 +399,8 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
 
     protected function linkToPage($pid, $ns = '') {
         print "trying to split the array from value $pid";
-        $splitted = split(":",$pid);
-        print_r($splitted);
-        $pidWONamespace = end($splitted);
+        print "namespace is $ns";
+        $pidWONamespace = str_replace($ns . ":","",$pid);
         print "splitted value is $pidWONamespace";
         return '<a href="' . hsc($this->getPidURL($pid, $ns)) . '">' . $pidWONamespace . '</a>';
     }

--- a/helper.php
+++ b/helper.php
@@ -239,21 +239,6 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         return $ret;
     }
 
-    public function getPidURL($pid, $ns = '') {
-        // wrap tag in quotes if non clean
-        $cpid = utf8_stripspecials($this->cleanTag($pid));
-        if ($cpid != utf8_strtolower($pid)) {
-            $pid = '"' . $pid . '"';
-        }
-
-        $ret = $ns . rawurlencode(":" . $pid);
-        /*if ($ns) {
-            $ret .= rawurlencode(' @' . $ns);
-        }*/
-
-        return str_replace("%3A",":",$ret);
-    }
-
     /**
      * Calculates the size levels for the given list of clouds
      *
@@ -300,7 +285,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
      *
      * @return string
      */
-    public function html_cloud($tags, $type, $func, $wrap = true, $return = false, $ns = '') {
+    public function html_cloud($tags, $type, $func, $wrap = true, $return = false, $ns = '', $info_text) {
         global $INFO;
 
         $hidden_str = $this->getConf('hiddenprefix');
@@ -313,7 +298,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         if (count($tags) === 0) {
             // Produce valid XHTML (ul needs a child)
             $this->setupLocale();
-            $ret .= '<li><div class="li">' . $this->lang['js']['no' . $type . 's'] . '</div></li>';
+            $ret .= '<li><div class="li">' . $info_text . '</div></li>';
         } else {
             $tags = $this->cloudData($tags);
             foreach ($tags as $val => $size) {
@@ -364,7 +349,6 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
      */
     protected function linkToPage($pid, $ns = '') {
         return html_wikilink($pid);
-
     }
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -247,7 +247,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $pid = '"' . $pid . '"';
         }
 
-        $ret = $ns . ":" . rawurlencode($pid);
+        $ret = $ns . rawurlencode($pid);
         /*if ($ns) {
             $ret .= "rawurlencode(' @' . $ns)";
         }*/

--- a/helper.php
+++ b/helper.php
@@ -247,10 +247,10 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $pid = '"' . $pid . '"';
         }
 
-        $ret = $ns . rawurldecode(":") . rawurlencode($pid);
-        /*if ($ns) {
-            $ret .= "rawurlencode(' @' . $ns)";
-        }*/
+        $ret = rawurlencode($pid);
+        if ($ns) {
+            $ret .= rawurlencode(' @' . $ns);
+        }
 
         return $ret;
     }

--- a/helper.php
+++ b/helper.php
@@ -202,8 +202,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         foreach ($res as $row) {
             $ret[$row['item']] = $row['cnt'];
         }
-
-        print "the result is: $ret \n";
+        print_r($ret);
         return $ret;
     }
 

--- a/helper.php
+++ b/helper.php
@@ -328,60 +328,6 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
     }
 
     /**
-     * Display a tag cloud
-     *
-     * @param array    $tags   list of tags => count
-     * @param string   $type   'tag'
-     * @param Callable $func   The function to print the link (gets tag and ns)
-     * @param bool     $wrap   wrap cloud in UL tags?
-     * @param bool     $return returnn HTML instead of printing?
-     * @param string   $ns     Add this namespace to search links
-     *
-     * @return string
-     */
-    public function html_cloud_pages($tags, $type, $func, $wrap = true, $return = false, $ns = '') {
-        global $INFO;
-
-        $hidden_str = $this->getConf('hiddenprefix');
-        $hidden_len = strlen($hidden_str);
-
-        $ret = '';
-        if ($wrap) {
-            $ret .= '<ul class="tagging_cloud clearfix">';
-        }
-        if (count($tags) === 0) {
-            // Produce valid XHTML (ul needs a child)
-            $this->setupLocale();
-            $ret .= '<li><div class="li">' . $this->lang['js']['nopages'] . '</div></li>';
-        } else {
-            $tags = $this->cloudData($tags);
-            foreach ($tags as $val => $size) {
-                // skip hidden tags for users that can't edit
-                if ($type === 'tag' and
-                    $hidden_len and
-                    substr($val, 0, $hidden_len) == $hidden_str and
-                    !($this->getUser() && $INFO['writable'])
-                ) {
-                    continue;
-                }
-
-                $ret .= '<li class="t' . $size . '"><div class="li">';
-                $ret .= call_user_func($func, $val, $ns);
-                $ret .= '</div></li>';
-            }
-        }
-        if ($wrap) {
-            $ret .= '</ul>';
-        }
-        if ($return) {
-            return $ret;
-        }
-        echo $ret;
-
-        return '';
-    }
-
-    /**
      * Get the link to a search for the given tag
      *
      * @param string $tag search for this tag

--- a/helper.php
+++ b/helper.php
@@ -247,7 +247,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $pid = '"' . $pid . '"';
         }
 
-        $ret = $ns; //rawurlencode($pid);
+        $ret = $ns . ":" . $pid; //rawurlencode($pid);
         /*if ($ns) {
             $ret .= "rawurlencode(' @' . $ns)";
         }*/

--- a/helper.php
+++ b/helper.php
@@ -252,7 +252,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $ret .= rawurlencode(' @' . $ns);
         }*/
 
-        return $ret;
+        return str_replace("%3A",":",$ret);
     }
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -193,7 +193,6 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
                 $limit
               ";
 
-        print "running sql query: $sql \n";
         // run query and turn into associative array
         $res = $db->query($sql, array_values($filter));
         $res = $db->res2arr($res);
@@ -202,7 +201,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         foreach ($res as $row) {
             $ret[$row['item']] = $row['cnt'];
         }
-        print_r($ret);
+        
         return $ret;
     }
 

--- a/helper.php
+++ b/helper.php
@@ -167,6 +167,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         }
         $where .= ' AND GETACCESSLEVEL(pid) >= ' . AUTH_READ;
 
+        
         // group and order
         if ($type === 'tag') {
             $groupby = 'CLEANTAG(tag)';
@@ -192,6 +193,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
                 $limit
               ";
 
+        print "running sql query: $sql";
         // run query and turn into associative array
         $res = $db->query($sql, array_values($filter));
         $res = $db->res2arr($res);

--- a/helper.php
+++ b/helper.php
@@ -404,7 +404,8 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         $namespace = array_pop(array_reverse(explode(":",$pid)));
         print "namespace from pid is $namespace";
         print "splitted value is $pidWONamespace";
-        return '<a href="' . $this->getPidURL($pidWONamespace, $namespace) . '">' . $pidWONamespace . '</a>';
+        return html_wikilink($pid);
+        //return '<a href="' . hsc($this->getPidURL($pidWONamespace, $namespace)) . '">' . $pidWONamespace . '</a>';
     }
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -398,7 +398,8 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
     }
 
     protected function linkToPage($pid, $ns = '') {
-        return '<a href="' . hsc($this->getPidURL($pid, $ns)) . '">' . $pid . '</a>';
+        $pidWONamespace = end(split(":",$pid));  
+        return '<a href="' . hsc($this->getPidURL($pid, $ns)) . '">' . $pidWONamespace . '</a>';
     }
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -247,7 +247,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $pid = '"' . $pid . '"';
         }
 
-        $ret = $ns . rawurlencode($pid);
+        $ret = $ns . rawurldecode(":") . rawurlencode($pid);
         /*if ($ns) {
             $ret .= "rawurlencode(' @' . $ns)";
         }*/

--- a/helper.php
+++ b/helper.php
@@ -285,7 +285,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
      *
      * @return string
      */
-    public function html_cloud($tags, $type, $func, $wrap = true, $return = false, $ns = '', $info_text) {
+    public function html_cloud($tags, $type, $func, $wrap = true, $return = false, $ns = '') {
         global $INFO;
 
         $hidden_str = $this->getConf('hiddenprefix');
@@ -298,7 +298,61 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         if (count($tags) === 0) {
             // Produce valid XHTML (ul needs a child)
             $this->setupLocale();
-            $ret .= '<li><div class="li">' . $info_text . '</div></li>';
+            $ret .= '<li><div class="li">' . $this->lang['js']['no' . $type . 's'] . '</div></li>';
+        } else {
+            $tags = $this->cloudData($tags);
+            foreach ($tags as $val => $size) {
+                // skip hidden tags for users that can't edit
+                if ($type === 'tag' and
+                    $hidden_len and
+                    substr($val, 0, $hidden_len) == $hidden_str and
+                    !($this->getUser() && $INFO['writable'])
+                ) {
+                    continue;
+                }
+
+                $ret .= '<li class="t' . $size . '"><div class="li">';
+                $ret .= call_user_func($func, $val, $ns);
+                $ret .= '</div></li>';
+            }
+        }
+        if ($wrap) {
+            $ret .= '</ul>';
+        }
+        if ($return) {
+            return $ret;
+        }
+        echo $ret;
+
+        return '';
+    }
+
+    /**
+     * Display a tag cloud
+     *
+     * @param array    $tags   list of tags => count
+     * @param string   $type   'tag'
+     * @param Callable $func   The function to print the link (gets tag and ns)
+     * @param bool     $wrap   wrap cloud in UL tags?
+     * @param bool     $return returnn HTML instead of printing?
+     * @param string   $ns     Add this namespace to search links
+     *
+     * @return string
+     */
+    public function html_cloud_pages($tags, $type, $func, $wrap = true, $return = false, $ns = '') {
+        global $INFO;
+
+        $hidden_str = $this->getConf('hiddenprefix');
+        $hidden_len = strlen($hidden_str);
+
+        $ret = '';
+        if ($wrap) {
+            $ret .= '<ul class="tagging_cloud clearfix">';
+        }
+        if (count($tags) === 0) {
+            // Produce valid XHTML (ul needs a child)
+            $this->setupLocale();
+            $ret .= '<li><div class="li">' . $this->lang['js']['nopages'] . '</div></li>';
         } else {
             $tags = $this->cloudData($tags);
             foreach ($tags as $val => $size) {

--- a/helper.php
+++ b/helper.php
@@ -398,7 +398,9 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
     }
 
     protected function linkToPage($pid, $ns = '') {
-        $pidWONamespace = end(split(":",$pid));  
+        print "trying to split the array";
+        $pidWONamespace = end(split(":",$pid));
+        print "splitted value is $pidWONamespace";
         return '<a href="' . hsc($this->getPidURL($pid, $ns)) . '">' . $pidWONamespace . '</a>';
     }
 

--- a/helper.php
+++ b/helper.php
@@ -247,7 +247,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $pid = '"' . $pid . '"';
         }
 
-        $ret = rawurlencode($pid);
+        $ret = "test"; //rawurlencode($pid);
         /*if ($ns) {
             $ret .= "rawurlencode(' @' . $ns)";
         }*/

--- a/helper.php
+++ b/helper.php
@@ -247,9 +247,9 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $pid = '"' . $pid . '"';
         }
 
-        $ret = rawurlencode($pid);
+        $ret = rawurlencode($ns);
         if ($ns) {
-            $ret .= rawurlencode(' @' . $ns);
+            $ret .= ":" . $pid ;
         }
 
         return $ret;

--- a/helper.php
+++ b/helper.php
@@ -247,7 +247,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $pid = '"' . $pid . '"';
         }
 
-        $ret = $ns . rawurlencode("%3A" . $pid);
+        $ret = $ns . rawurlencode(":" . $pid);
         /*if ($ns) {
             $ret .= rawurlencode(' @' . $ns);
         }*/

--- a/helper.php
+++ b/helper.php
@@ -193,7 +193,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
                 $limit
               ";
 
-        print "running sql query: $sql";
+        print "running sql query: $sql \n";
         // run query and turn into associative array
         $res = $db->query($sql, array_values($filter));
         $res = $db->res2arr($res);

--- a/helper.php
+++ b/helper.php
@@ -247,10 +247,10 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $pid = '"' . $pid . '"';
         }
 
-        $ret = rawurlencode($pid);
-        if ($ns) {
+        $ret = $ns . rawurlencode("%3A" . $pid);
+        /*if ($ns) {
             $ret .= rawurlencode(' @' . $ns);
-        }
+        }*/
 
         return $ret;
     }

--- a/helper.php
+++ b/helper.php
@@ -247,7 +247,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $pid = '"' . $pid . '"';
         }
 
-        $ret = $ns . ":" . $pid; //rawurlencode($pid);
+        $ret = $ns . ":" . rawurlencode($pid);
         /*if ($ns) {
             $ret .= "rawurlencode(' @' . $ns)";
         }*/

--- a/helper.php
+++ b/helper.php
@@ -404,7 +404,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         $namespace = array_pop(array_reverse(explode(":",$pid)));
         print "namespace from pid is $namespace";
         print "splitted value is $pidWONamespace";
-        return '<a href="' . hsc($this->getPidURL($pid, $namespace)) . '">' . $pidWONamespace . '</a>';
+        return '<a href="' . hsc($this->getPidURL($pidWONamespace, $namespace)) . '">' . $pidWONamespace . '</a>';
     }
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -400,10 +400,11 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
     protected function linkToPage($pid, $ns = '') {
         print "trying to split the array from value $pid";
         print "namespace is $ns";
-        $pidWONamespace = explode(":",$pid);
-        $pidWONamespaceEnd = end($pidWONamespace);
-        print "splitted value is $pidWONamespaceEnd";
-        return '<a href="' . hsc($this->getPidURL($pid, $ns)) . '">' . $pidWONamespaceEnd . '</a>';
+        $pidWONamespace = end(explode(":",$pid));
+        $namespace = array_pop(array_reverse(explode(":",$pid)));
+        print "namespace from pid is $namespace";
+        print "splitted value is $pidWONamespace";
+        return '<a href="' . hsc($this->getPidURL($pid, $namespace)) . '">' . $pidWONamespace . '</a>';
     }
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -203,6 +203,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $ret[$row['item']] = $row['cnt'];
         }
 
+        print "the result is: $ret \n";
         return $ret;
     }
 

--- a/helper.php
+++ b/helper.php
@@ -247,10 +247,10 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $pid = '"' . $pid . '"';
         }
 
-        $ret = rawurlencode($ns);
-        if ($ns) {
-            $ret .= ":" . $pid ;
-        }
+        $ret = rawurlencode($pid);
+        /*if ($ns) {
+            $ret .= "rawurlencode(' @' . $ns)";
+        }*/
 
         return $ret;
     }

--- a/helper.php
+++ b/helper.php
@@ -343,48 +343,6 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         return '';
     }
 
-    public function html_cloud_pid($tags, $type, $func, $wrap = true, $return = false, $ns = '') {
-        global $INFO;
-
-        $hidden_str = $this->getConf('hiddenprefix');
-        $hidden_len = strlen($hidden_str);
-
-        $ret = '';
-        if ($wrap) {
-            $ret .= '<ul class="tagging_cloud clearfix">';
-        }
-        if (count($tags) === 0) {
-            // Produce valid XHTML (ul needs a child)
-            $this->setupLocale();
-            $ret .= '<li><div class="li">' . $this->lang['js']['no' . $type . 's'] . '</div></li>';
-        } else {
-            $tags = $this->cloudData($tags);
-            foreach ($tags as $val => $size) {
-                // skip hidden tags for users that can't edit
-                if ($type === 'tag' and
-                    $hidden_len and
-                    substr($val, 0, $hidden_len) == $hidden_str and
-                    !($this->getUser() && $INFO['writable'])
-                ) {
-                    continue;
-                }
-
-                $ret .= '<li class="t' . $size . '"><div class="li">';
-                $ret .= call_user_func($func, $val, $ns);
-                $ret .= '</div></li>';
-            }
-        }
-        if ($wrap) {
-            $ret .= '</ul>';
-        }
-        if ($return) {
-            return $ret;
-        }
-        echo $ret;
-
-        return '';
-    }
-
     /**
      * Get the link to a search for the given tag
      *
@@ -397,15 +355,17 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         return '<a href="' . hsc($this->getTagSearchURL($tag, $ns)) . '">' . $tag . '</a>';
     }
 
+    /**
+     * Get the link to a page for the given pid
+     *
+     * @param string $pid search for this tag
+     * @param string $ns  limit search to this namespace
+     *
+     * @return string
+     */
     protected function linkToPage($pid, $ns = '') {
-        print "trying to split the array from value $pid";
-        print "namespace is $ns";
-        $pidWONamespace = end(explode(":",$pid));
-        $namespace = array_pop(array_reverse(explode(":",$pid)));
-        print "namespace from pid is $namespace";
-        print "splitted value is $pidWONamespace";
         return html_wikilink($pid);
-        //return '<a href="' . hsc($this->getPidURL($pidWONamespace, $namespace)) . '">' . $pidWONamespace . '</a>';
+
     }
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -400,9 +400,10 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
     protected function linkToPage($pid, $ns = '') {
         print "trying to split the array from value $pid";
         print "namespace is $ns";
-        $pidWONamespace = str_replace($ns . ":","",$pid);
-        print "splitted value is $pidWONamespace";
-        return '<a href="' . hsc($this->getPidURL($pid, $ns)) . '">' . $pidWONamespace . '</a>';
+        $pidWONamespace = explode(":",$pid);
+        $pidWONamespaceEnd = end($pidWONamespace);
+        print "splitted value is $pidWONamespaceEnd";
+        return '<a href="' . hsc($this->getPidURL($pid, $ns)) . '">' . $pidWONamespaceEnd . '</a>';
     }
 
     /**

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -28,6 +28,7 @@ $lang['no_admin']              = 'Fehler. Nur Admins können Schlagworte bearbei
 $lang['search_section_title']  = 'Seiten mit Schlagwort';
 $lang['search_section_title_other']  = 'Seiten mit Suchbegriff';
 $lang['js']['notags']          = 'Keine Schlagworte vergeben';
+$lang['js']['notag']          = 'Kein Schlagwort angegeben';
 $lang['js']['nopages']         = 'Keine Seiten mit diesem Schlagwort';
 $lang['js']['admin_change_tag'] = 'Schlagworte bearbeiten';
 $lang['tagjmp_error']          = 'Es konnte keine Seite mit Schlagwort %s gefunden werden';

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -26,6 +26,7 @@ $lang['admin sort descending'] = 'Absteigend sortieren';
 $lang['toggle admin mode']     = 'Administrieren';
 $lang['no_admin']              = 'Fehler. Nur Admins können Schlagworte bearbeiten.';
 $lang['search_section_title']  = 'Seiten mit Schlagwort';
+$lang['search_section_title_other']  = 'Seiten mit Suchbegriff';
 $lang['js']['notags']          = 'Keine Schlagworte vergeben';
 $lang['js']['nopages']         = 'Keine Seiten mit diesem Schlagwort';
 $lang['js']['admin_change_tag'] = 'Schlagworte bearbeiten';

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -28,7 +28,6 @@ $lang['no_admin']              = 'Fehler. Nur Admins können Schlagworte bearbei
 $lang['search_section_title']  = 'Seiten mit Schlagwort';
 $lang['search_section_title_other']  = 'Seiten mit Suchbegriff';
 $lang['js']['notags']          = 'Keine Schlagworte vergeben';
-$lang['js']['notag']          = 'Kein Schlagwort angegeben';
 $lang['js']['nopages']         = 'Keine Seiten mit diesem Schlagwort';
 $lang['js']['admin_change_tag'] = 'Schlagworte bearbeiten';
 $lang['tagjmp_error']          = 'Es konnte keine Seite mit Schlagwort %s gefunden werden';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -25,6 +25,7 @@ $lang['toggle admin mode']         = 'Tag Admin';
 $lang['no_admin']                  = 'Error. Only admins can modify tags.';
 
 $lang['search_section_title']      = 'Pages tagged';
+$lang['search_section_title_other']      = 'Pages containing';
 $lang['js']['notags']              = 'No tags, yet';
 $lang['js']['nopages']             = 'No pages with this tag, yet';
 $lang['js']['admin_change_tag']    = 'Change the tag';

--- a/syntax.php
+++ b/syntax.php
@@ -83,9 +83,15 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
                 $renderer->info['cache'] = false;
                 
                 $pids = $hlp->findItems(array('tag' => $data['tag']), 'pid', $data['limit']);
-            
-                $renderer->doc .= $hlp->html_cloud_pages($pids, 'tag', array($hlp, 'linkToPage'), true, true);
-
+                if (count($pids) === 0) {
+                    $ret = '<ul class="tagging_cloud clearfix">';
+                    $ret .= '<li><div class="li">' . $this->lang['js']['nopages'] . '</div></li>';
+                    $ret .= '</ul>';
+                    $renderer->doc .= $hlp->$ret;
+                } else {
+                    $renderer->doc .= $hlp->html_cloud($pids, 'tag', array($hlp, 'linkToPage'), true, true);
+                }
+                
                 break;
             case 'ns':
                 $renderer->info['cache'] = false;

--- a/syntax.php
+++ b/syntax.php
@@ -82,7 +82,7 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
                 $renderer->info['cache'] = false;
                 
                 $pids = $hlp->findItems(array('tag' => $data['tag']), 'pid', $data['limit']);
-                $renderer->doc .= $hlp->html_cloud_pid($pids, 'tag', array($hlp, 'linkToPage'), true, true);
+                $renderer->doc .= $hlp->html_cloud($pids, 'tag', array($hlp, 'linkToPage'), true, true);
 
                 break;
             case 'ns':

--- a/syntax.php
+++ b/syntax.php
@@ -75,16 +75,16 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
                     $data['user'] = $_SERVER['REMOTE_USER'];
                 }
                 $tags = $hlp->findItems(array('tagger' => $data['user']), 'tag', $data['limit']);
-                $info_text = $this->lang['js']['notags'];
-                $renderer->doc .= $hlp->html_cloud($tags, 'tag', array($hlp, 'linkToSearch'), true, true, $info_text);
+                
+                $renderer->doc .= $hlp->html_cloud($tags, 'tag', array($hlp, 'linkToSearch'), true, true);
 
                 break;
             case 'tag':
                 $renderer->info['cache'] = false;
                 
                 $pids = $hlp->findItems(array('tag' => $data['tag']), 'pid', $data['limit']);
-                $info_text = $this->lang['js']['nopages'];
-                $renderer->doc .= $hlp->html_cloud($pids, 'tag', array($hlp, 'linkToPage'), true, true, $info_text);
+            
+                $renderer->doc .= $hlp->html_cloud_pages($pids, 'tag', array($hlp, 'linkToPage'), true, true);
 
                 break;
             case 'ns':

--- a/syntax.php
+++ b/syntax.php
@@ -83,14 +83,8 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
                 $renderer->info['cache'] = false;
                 
                 $pids = $hlp->findItems(array('tag' => $data['tag']), 'pid', $data['limit']);
-                if (count($pids) === 0) {
-                    $ret = '<ul class="tagging_cloud clearfix">';
-                    $ret .= '<li><div class="li">' . $this->lang['js']['nopages'] . '</div></li>';
-                    $ret .= '</ul>';
-                    $renderer->doc .= $ret;
-                } else {
-                    $renderer->doc .= $hlp->html_cloud($pids, 'tag', array($hlp, 'linkToPage'), true, true);
-                }
+
+                $renderer->doc .= $hlp->html_cloud($pids, 'tag', array($hlp, 'linkToPage'), true, true);
                 
                 break;
             case 'ns':

--- a/syntax.php
+++ b/syntax.php
@@ -87,7 +87,7 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
                     $ret = '<ul class="tagging_cloud clearfix">';
                     $ret .= '<li><div class="li">' . $this->lang['js']['nopages'] . '</div></li>';
                     $ret .= '</ul>';
-                    $renderer->doc .= $hlp->$ret;
+                    $renderer->doc .= $ret;
                 } else {
                     $renderer->doc .= $hlp->html_cloud($pids, 'tag', array($hlp, 'linkToPage'), true, true);
                 }

--- a/syntax.php
+++ b/syntax.php
@@ -82,7 +82,7 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
                 $renderer->info['cache'] = false;
                 
                 $pids = $hlp->findItems(array('tag' => $data['tag']), 'pid', $data['limit']);
-                $renderer->doc .= $hlp->html_cloud($pids, 'tag', array($hlp, 'linkToSearch'), true, true);
+                $renderer->doc .= $hlp->html_cloud_pid($pids, 'tag', array($hlp, 'linkToPage'), true, true);
 
                 break;
             case 'ns':

--- a/syntax.php
+++ b/syntax.php
@@ -45,6 +45,11 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
                     $data['user'] = trim($matches[2]);
                 }
                 break;
+            case 'tag':
+                if (count($matches) > 2) {
+                    $data['tag'] = trim($matches[2]);
+                }
+                break;
             case 'ns':
                 if (count($matches) > 2) {
                     $data['ns'] = trim($matches[2]);

--- a/syntax.php
+++ b/syntax.php
@@ -75,10 +75,8 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
                 break;
             case 'tag':
                 $renderer->info['cache'] = false;
-                if (!isset($data['tag'])) {
-                    $data['tag'] = $_SERVER['REMOTE_USER'];
-                }
-                $tags = $hlp->findItems(array('tagger' => $data['tag']), 'tag', $data['limit']);
+                
+                $tags = $hlp->findItems(array('tag' => $data['tag']), 'pid', $data['limit']);
                 $renderer->doc .= $hlp->html_cloud($tags, 'tag', array($hlp, 'linkToSearch'), true, true);
 
                 break;

--- a/syntax.php
+++ b/syntax.php
@@ -81,8 +81,8 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
             case 'tag':
                 $renderer->info['cache'] = false;
                 
-                $tags = $hlp->findItems(array('tag' => $data['tag']), 'pid', $data['limit']);
-                $renderer->doc .= $hlp->html_cloud($tags, 'tag', array($hlp, 'linkToSearch'), true, true);
+                $pids = $hlp->findItems(array('tag' => $data['tag']), 'pid', $data['limit']);
+                $renderer->doc .= $hlp->html_cloud($pids, 'tag', array($hlp, 'linkToSearch'), true, true);
 
                 break;
             case 'ns':

--- a/syntax.php
+++ b/syntax.php
@@ -73,6 +73,15 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
                 $renderer->doc .= $hlp->html_cloud($tags, 'tag', array($hlp, 'linkToSearch'), true, true);
 
                 break;
+            case 'tag':
+                $renderer->info['cache'] = false;
+                if (!isset($data['tag'])) {
+                    $data['tag'] = $_SERVER['REMOTE_USER'];
+                }
+                $tags = $hlp->findItems(array('tagger' => $data['tag']), 'tag', $data['limit']);
+                $renderer->doc .= $hlp->html_cloud($tags, 'tag', array($hlp, 'linkToSearch'), true, true);
+
+                break;
             case 'ns':
                 $renderer->info['cache'] = false;
                 if (!isset($data['ns'])) {

--- a/syntax.php
+++ b/syntax.php
@@ -75,14 +75,16 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
                     $data['user'] = $_SERVER['REMOTE_USER'];
                 }
                 $tags = $hlp->findItems(array('tagger' => $data['user']), 'tag', $data['limit']);
-                $renderer->doc .= $hlp->html_cloud($tags, 'tag', array($hlp, 'linkToSearch'), true, true);
+                $info_text = $this->lang['js']['notags'];
+                $renderer->doc .= $hlp->html_cloud($tags, 'tag', array($hlp, 'linkToSearch'), true, true, $info_text);
 
                 break;
             case 'tag':
                 $renderer->info['cache'] = false;
                 
                 $pids = $hlp->findItems(array('tag' => $data['tag']), 'pid', $data['limit']);
-                $renderer->doc .= $hlp->html_cloud($pids, 'tag', array($hlp, 'linkToPage'), true, true);
+                $info_text = $this->lang['js']['nopages'];
+                $renderer->doc .= $hlp->html_cloud($pids, 'tag', array($hlp, 'linkToPage'), true, true, $info_text);
 
                 break;
             case 'ns':


### PR DESCRIPTION
added another `<h3>` to searchresult page in action.php to better visually seperate tag-results from normal search results.
If there aren't any tag-searchresults, the newly added `<h3>` heading isn't displayed and searchresult looks just as allways