### PR TITLE
list pages per tag

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -327,6 +327,37 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
     }
 
     /**
+     * Display a List of Page Links
+     *
+     * @param array    $pids   list of pids => count
+     * @return string
+     */
+    public function html_page_list($pids) {
+        global $INFO;
+
+        $ret = '<div class="search_quickresult">';
+        $ret .= '<ul class="search_quickhits">';
+        
+        if (count($pids) === 0) {
+            // Produce valid XHTML (ul needs a child)
+            $this->setupLocale();
+            $ret .= '<li><div class="li">' . $this->lang['js']['nopages'] . '</div></li>';
+        } else {
+            foreach ($pids as $val => $size) {
+                $ret .= '<li><div class="li">';
+                $ret .= html_wikilink($val);
+                $ret .= '</div></li>';
+            }
+        }
+
+        $ret .= '</ul>';
+        $ret .= '</div>';
+        $ret .= '<div class="clearer"></div>';
+        
+        return $ret;
+    }
+
+    /**
      * Get the link to a search for the given tag
      *
      * @param string $tag search for this tag

--- a/syntax.php
+++ b/syntax.php
@@ -45,6 +45,11 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
                     $data['user'] = trim($matches[2]);
                 }
                 break;
+            case 'tag':
+                if (count($matches) > 2) {
+                    $data['tag'] = trim($matches[2]);
+                }
+                break;
             case 'ns':
                 if (count($matches) > 2) {
                     $data['ns'] = trim($matches[2]);
@@ -70,8 +75,17 @@ class syntax_plugin_tagging extends DokuWiki_Syntax_Plugin {
                     $data['user'] = $_SERVER['REMOTE_USER'];
                 }
                 $tags = $hlp->findItems(array('tagger' => $data['user']), 'tag', $data['limit']);
+                
                 $renderer->doc .= $hlp->html_cloud($tags, 'tag', array($hlp, 'linkToSearch'), true, true);
 
+                break;
+            case 'tag':
+                $renderer->info['cache'] = false;
+                
+                $pids = $hlp->findItems(array('tag' => $data['tag']), 'pid', $data['limit']);
+
+                $renderer->doc .= $hlp->html_page_list($pids);
+               
                 break;
             case 'ns':
                 $renderer->info['cache'] = false;


### PR DESCRIPTION
added a new feature which shows all pages tagged with a specific tag. Using `{{tagging::tag>tagname}}` will return an unformatted list of that pages.

also: added another `<h3>` to searchresult page in action.php to better visually seperate tag-results from normal search results.
If there aren't any tag-searchresults, the newly added `<h3>` heading isn't displayed and searchresult looks just as always