### PR TITLE
Update tags when move plugin has moved a page

### DIFF
--- a/action.php
+++ b/action.php
@@ -28,6 +28,11 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
             'DOKUWIKI_STARTED', 'AFTER', $this,
             'js_add_security_token'
         );
+
+        $controller->register_hook(
+            'PLUGIN_MOVE_PAGE_RENAME', 'AFTER', $this,
+            'update_moved_page'
+        );
     }
 
     /**
@@ -278,6 +283,8 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
         $oldID = $ID;
         foreach ($pages as $page => $cnt) {
             $ID = $page;
+            // skip nonexistent pages
+            if (!page_exists($ID)) continue;
             $results .= '<li><div class="li">';
             $results .= html_wikilink($page);
             $results .= '</div></li>';
@@ -299,5 +306,21 @@ class action_plugin_tagging extends DokuWiki_Action_Plugin {
         }
 
 
+    }
+
+    /**
+     * Updates tagging database after a page has been moved/renamed by the move plugin
+     *
+     * @param Doku_Event $event
+     * @param $param
+     */
+    public function update_moved_page(Doku_Event $event, $param)
+    {
+        $src = $event->data['src_id'];
+        $dst = $event->data['dst_id'];
+
+        /** @var helper_plugin_tagging $hlp */
+        $hlp = plugin_load('helper', 'tagging');
+        $hlp->renamePage($src, $dst);
     }
 }

--- a/helper.php
+++ b/helper.php
@@ -537,4 +537,18 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
 
         msg(sprintf($this->getLang("admin deleted"), count($tags), $numAffectedPages), 1);
     }
+
+    /**
+     * Updates tags with a new page name
+     *
+     * @param string $oldName
+     * @param string $newName
+     */
+    public function renamePage($oldName, $newName) {
+        $db = $this->getDb();
+        $res = $db->query('SELECT * FROM taggings WHERE pid = ?', $oldName);
+        if (!empty($db->res2arr($res))) {
+            $db->query('UPDATE taggings SET pid = ? WHERE pid = ?', $newName, $oldName);
+        }
+    }
 }

--- a/helper.php
+++ b/helper.php
@@ -546,9 +546,6 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
      */
     public function renamePage($oldName, $newName) {
         $db = $this->getDb();
-        $res = $db->query('SELECT * FROM taggings WHERE pid = ?', $oldName);
-        if (!empty($db->res2arr($res))) {
-            $db->query('UPDATE taggings SET pid = ? WHERE pid = ?', $newName, $oldName);
-        }
+        $db->query('UPDATE taggings SET pid = ? WHERE pid = ?', $newName, $oldName);
     }
 }


### PR DESCRIPTION
- responds to event emitted by the move plugin and updates taggings
- checks for non-existent pages when displaying search results