### PR TITLE
Add config to disable namespace column in overview tables

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -2,4 +2,4 @@
 $conf['cloudlimit']     = 50;
 $conf['singleusermode'] = 0;
 $conf['hiddenprefix']   = '@';
-
+$conf['hidens']         = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -2,3 +2,4 @@
 $meta['cloudlimit']     = array('numeric', '_min' => 0);
 $meta['singleusermode'] = array('onoff');
 $meta['hiddenprefix']   = array('string');
+$meta['hidens'] = array('onoff');

--- a/helper.php
+++ b/helper.php
@@ -654,10 +654,19 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
 
         $headers = array(
             array('value' => $this->getLang('admin tag'), 'sort_by' => 'tid'),
-            array('value' => $this->getLang('admin occurrence'), 'sort_by' => 'count'),
-            array('value' => $this->getLang('admin namespaces'), 'sort_by' => 'ns'),
+            array('value' => $this->getLang('admin occurrence'), 'sort_by' => 'count')
+        );
+
+        if (!$this->conf['hidens']) {
+            array_push(
+                $headers,
+                ['value' => $this->getLang('admin namespaces'), 'sort_by' => 'ns']
+            );
+        }
+
+        array_push($headers,
             array('value' => $this->getLang('admin taggers'), 'sort_by' => 'taggers'),
-            array('value' => $this->getLang('admin actions'), 'sort_by' => false),
+            array('value' => $this->getLang('admin actions'), 'sort_by' => false)
         );
 
         $sort = explode(',', $this->getParam('sort'));
@@ -693,12 +702,13 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
          */
         $form->addTagOpen('table')->addClass('inline plugin_tagging');
 
+        $nscol = $this->conf['hidens'] ? '' : '<col class="wide-col"></col>';
         $form->addHTML(
             '<colgroup>
                 <col></col>
-                <col class="narrow-col"></col>
-                <col class="wide-col"></col>
-                <col></col>
+                <col class="narrow-col"></col>'
+                . $nscol .
+                '<col></col>
                 <col class="narrow-col"></col>
             </colgroup>'
         );
@@ -763,7 +773,9 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $form->addHTML( hsc($tagname) . '</a>');
             $form->addHTML('</td>');
             $form->addHTML('<td>' . $taginfo['count'] . '</td>');
-            $form->addHTML('<td>' . hsc($ns) . '</td>');
+            if (!$this->conf['hidens']) {
+                $form->addHTML('<td>' . hsc($ns) . '</td>');
+            }
             $form->addHTML('<td>' . hsc($taggers) . '</td>');
 
             /**

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -7,3 +7,4 @@
 $lang['cloudlimit']            = 'Maximale Anzahl an Schlagworten die in einer Schlagwort-Wolke angezeigt werden. 0 zeigt alle Schlagworte an.';
 $lang['singleusermode']        = 'Single-User-Mode aktivieren. D.h. alle Schlagworte können von allen bearbeitet werden.';
 $lang['hiddenprefix']          = 'Schlagworte mit diesem Prefix werden Nutzern, die nur die Leseberechtigung für eine Seite haben, nicht angezeigt.';
+$lang['hidens']                = 'Namensraum-Spalte in den Übersichtstabellen ausblenden.';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -2,3 +2,4 @@
 $lang['cloudlimit']     = 'Maximum tags to show in in-pgae tag clouds. Set 0 for all matching tags';
 $lang['singleusermode'] = 'Enable single user moder, eg. all tags can be edited by anyone.';
 $lang['hiddenprefix']   = 'Tags with this prefix will not be shown to read-only users';
+$lang['hidens']         = 'Hide the amespace column in overview tables';


### PR DESCRIPTION
Namespaces are already visible in the popup listing of tagged pages. To save space, this PR introduces a global config option to hide the namespace column in admin and user tables.