### PR TITLE
Add cleanup tool to admin interface

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -28,7 +28,7 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
     function handle() {
 
         if (!empty($_REQUEST['cmd']['clean'])) {
-            $this->hlp->deleteInvalidTaggings();
+            checkSecurityToken() && $this->hlp->deleteInvalidTaggings();
         }
 
         if (!$this->hlp->getParams()) {

--- a/admin.php
+++ b/admin.php
@@ -26,6 +26,11 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
      * Handle tag actions
      */
     function handle() {
+
+        if (!empty($_REQUEST['cmd']['clean'])) {
+            $this->hlp->deleteInvalidTaggings();
+        }
+
         if (!$this->hlp->getParams()) {
             $this->hlp->setDefaultSort();
             return false;
@@ -44,5 +49,7 @@ class admin_plugin_tagging extends DokuWiki_Admin_Plugin {
     public function html() {
         echo $this->locale_xhtml('intro');
         echo $this->hlp->html_table();
+        echo $this->locale_xhtml('clean');
+        echo $this->hlp->html_clean();
     }
 }

--- a/helper.php
+++ b/helper.php
@@ -1,4 +1,7 @@
 <?php
+
+use dokuwiki\Form\Form;
+
 /**
  * Tagging Plugin (hlper component)
  *
@@ -545,6 +548,19 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
     }
 
     /**
+     * Delete taggings of nonexistent pages
+     */
+    public function deleteInvalidTaggings()
+    {
+        $db = $this->getDB();
+        $query = 'DELETE    FROM "taggings"
+                            WHERE PAGEEXISTS(pid) IS FALSE
+                 ';
+        $res = $db->query($query);
+        $db->res_close($res);
+    }
+
+    /**
      * Updates tags with a new page name
      *
      * @param string $oldName
@@ -806,6 +822,42 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
     }
 
     /**
+     * Display tag cleaner
+     *
+     * @return string
+     */
+    public function html_clean()
+    {
+        $invalid = $this->getInvalidTaggings();
+
+        if (!$invalid) {
+            return '<p><strong>' . $this->getLang('admin no invalid') . '</strong></p>';
+        }
+
+        $form = new Form();
+        $form->setHiddenField('do', 'admin');
+        $form->setHiddenField('page', $this->getPluginName());
+        $form->addButton('cmd[clean]', $this->getLang('admin clean'));
+
+        $html = $form->toHTML();
+
+        $html .= '<div class="table"><table class="inline plugin_tagging">';
+        $html .= '<thead><tr><th>' .
+            $this->getLang('admin nonexistent page') .
+            '</th><th>' .
+            $this->getLang('admin tags') .
+            '</th></tr></thead><tbody>';
+
+        foreach ($invalid as $row) {
+            $html .= '<tr><td>' . $row['pid'] . '</td><td>' . $row['tags'] . '</td></tr>';
+        }
+
+        $html .= '</tbody></table></div>';
+
+        return $html;
+    }
+
+    /**
      * Returns all tagging parameters from the query string
      *
      * @return mixed
@@ -898,5 +950,23 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
             $having .= implode(' AND ', $parts);
         }
         return [$having, $params];
+    }
+
+    /**
+     * Returns taggings of nonexistent pages
+     *
+     * @return array
+     */
+    protected function getInvalidTaggings()
+    {
+        $db = $this->getDB();
+        $query = 'SELECT    "pid",
+                            GROUP_CONCAT(CLEANTAG("tag")) AS "tags"
+                            FROM "taggings"
+                            WHERE PAGEEXISTS(pid) IS FALSE
+                            GROUP BY pid
+                 ';
+        $res = $db->query($query);
+        return $db->res2arr($res);
     }
 }

--- a/lang/de/clean.txt
+++ b/lang/de/clean.txt
@@ -1,0 +1,3 @@
+===== Tag-Datenbank bereinigen =====
+
+Hier können Sie alle ungültigen Taggings löschen: Tags welche auf nicht existierende Seiten verweisen. Gültige Tags bleiben unversehrt.

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -7,6 +7,8 @@
  */
 $lang['menu']                  = 'Schlagwort-Einstellungen';
 $lang['admin tag']             = 'Schlagwort-Benennung';
+$lang['admin tags']            = 'Schlagworte';
+$lang['admin nonexistent page'] = 'Getaggte nicht existierende Seite';
 $lang['admin occurrence']      = 'Häufigkeit';
 $lang['admin namespaces']      = 'Namensräume';
 $lang['admin taggers']         = 'Gespeichert von';
@@ -26,6 +28,8 @@ $lang['admin filter button']   = 'Filter';
 $lang['admin deleted']         = 'Sie haben %d Schlagworte auf %d Seiten gelöscht';
 $lang['admin sort ascending']  = 'Aufsteigend sortieren';
 $lang['admin sort descending'] = 'Absteigend sortieren';
+$lang['admin no invalid']      = 'Keine ungültigen Tags gefunden.';
+$lang['admin clean']           = 'Alle ungültigen Taggings unwiederruflich löschen';
 $lang['toggle admin mode']     = 'Administrieren';
 $lang['no_admin']              = 'Fehler. Nur Admins können Schlagworte bearbeiten.';
 $lang['search_section_title']  = 'Seiten mit Schlagwort';

--- a/lang/en/clean.txt
+++ b/lang/en/clean.txt
@@ -1,0 +1,3 @@
+===== Clean up tag database =====
+
+Here you can delete all invalid taggings (tags pointing to nonexistent pages). No valid taggings will be removed.

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -4,6 +4,8 @@
 $lang['menu'] = 'View and Change Tags';
 
 $lang['admin tag']                 = 'Tag name';
+$lang['admin tags']                = 'Tags';
+$lang['admin nonexistent page']    = 'Tagged nonexistent page';
 $lang['admin occurrence']          = 'Occurrence';
 $lang['admin namespaces']          = 'Namespaces';
 $lang['admin taggers']             = 'Saved by';
@@ -23,6 +25,8 @@ $lang['admin filter button']       = 'Filter';
 $lang['admin deleted']             = 'You have deleted %d tags on %d pages';
 $lang['admin sort ascending']      = 'Sort ascending';
 $lang['admin sort descending']     = 'Sort descending';
+$lang['admin no invalid']          = 'No invalid tags found.';
+$lang['admin clean']               = 'Irrevocably delete all invalid taggings';
 $lang['toggle admin mode']         = 'Tag Admin';
 
 $lang['no_admin']                  = 'Error. Only admins can modify tags.';


### PR DESCRIPTION
This PR adds a simple db cleaner to the admin interface. It lists all invalid taggings (= tagged page does not exist) and lets the admin remove them all by clicking a button.