### PR TITLE
Fix non-namespaced links

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -333,17 +333,14 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
      * @return string
      */
     public function html_page_list($pids) {
-        global $INFO;
-
         $ret = '<div class="search_quickresult">';
         $ret .= '<ul class="search_quickhits">';
-        
+
         if (count($pids) === 0) {
             // Produce valid XHTML (ul needs a child)
-            $this->setupLocale();
             $ret .= '<li><div class="li">' . $this->lang['js']['nopages'] . '</div></li>';
         } else {
-            foreach ($pids as $val => $size) {
+            foreach (array_keys($pids) as $val) {
                 $ret .= '<li><div class="li">';
                 $ret .= html_wikilink($val);
                 $ret .= '</div></li>';
@@ -353,7 +350,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         $ret .= '</ul>';
         $ret .= '</div>';
         $ret .= '<div class="clearer"></div>';
-        
+
         return $ret;
     }
 

--- a/helper.php
+++ b/helper.php
@@ -342,7 +342,7 @@ class helper_plugin_tagging extends DokuWiki_Plugin {
         } else {
             foreach (array_keys($pids) as $val) {
                 $ret .= '<li><div class="li">';
-                $ret .= html_wikilink($val);
+                $ret .= html_wikilink(":$val");
                 $ret .= '</div></li>';
             }
         }


### PR DESCRIPTION
Merged PR #50 needs a fix for non-namespaced ids of tagged pages.

This removes unused variables as well.